### PR TITLE
Console.log missing from reducer in master

### DIFF
--- a/src/reducers/manageTodo.js
+++ b/src/reducers/manageTodo.js
@@ -1,6 +1,7 @@
 export default function manageTodo(state = {
   todos: [],
 }, action) {
+  console.log(action)
   switch (action.type) {
     case 'ADD_TODO':
 


### PR DESCRIPTION
The README states, "There is a console.log in our reducer that displays actions. Clicking the delete button should log an action with the todo's text content as the payload."

This console.log is not present in the reducer, manageTodo.js, when the project is initially cloned down. Please add this console.log in to make the codealong easier to follow.

Best wishes,
Kayla